### PR TITLE
Weather support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+#Ignore lock-waf files
+.lock-waf*
+
+#Ignore all build files
+build/*
+
+#Ignore node modules
+node_modules/*
+
+#Ignore wscript
+wscript

--- a/package.json
+++ b/package.json
@@ -25,7 +25,11 @@
             "monochrome_enabled",
             "bg_color_bw",
             "enable_flick",
-            "flick_show_duration"
+            "flick_show_duration",
+            "enable_weather",
+            "temperature",
+            "temperature_format",
+            "weather_api_key"
         ],
         "projectType": "native",
         "resources": {

--- a/src/c/globals.h
+++ b/src/c/globals.h
@@ -30,6 +30,11 @@
 #define BATTERY_W 32
 #define BATTERY_H 32
 
+#define WEATHER_X 65
+#define WEATHER_Y 145
+#define WEATHER_W 32
+#define WEATHER_H 20
+
 #define TIME_SMALL_X 101
 #define TIME_SMALL_Y 145
 #define TIME_SMALL_W 38
@@ -59,7 +64,7 @@
 
 Window *main_window;                                  
 
-TextLayer *layer_menubar_text, *layer_time, *layer_date;
+TextLayer *layer_menubar_text, *layer_weather_text, *layer_time, *layer_date;
 
 
 BitmapLayer *layer_desktop_icons,*layer_desktop_text, *layer_menubar,*layer_window,*layer_bt, *layer_qt, *layer_battery;                          
@@ -74,7 +79,7 @@ GBitmap *bitmap_desktop_text,*bitmap_desktop_icons_bw, *bitmap_menubar_bw,*bitma
 GFont font_menubar, font_date, font_time;
 
 GColor color_desktop_text;
-int battery_level;
+int battery_level, temperature;
 AppTimer *timer;
 
 bool flick_show_window;
@@ -99,6 +104,9 @@ typedef struct ClaySettings {
   bool date_format;
   bool flick_enabled;
   char flick_show_duration;
+  bool weather_enabled;
+  bool temperature_format;
+  char* weather_api_key;
 } ClaySettings;
 
 // An instance of the struct

--- a/src/c/settings.c
+++ b/src/c/settings.c
@@ -23,6 +23,9 @@ void load_default_settings() {
   settings.date_format = false;
   settings.flick_enabled = false;
   settings.flick_show_duration = 10;
+  settings.weather_enabled = false;
+  settings.temperature_format = false;
+  settings.weather_api_key = "1111111111";
   
   #ifdef PBL_COLOR  
   settings.bg_color = GColorTiffanyBlue;
@@ -104,6 +107,28 @@ void inbox_received_handler(DictionaryIterator *iter, void *context) {
   Tuple *show_duration_t = dict_find(iter, MESSAGE_KEY_flick_show_duration);  
   if(window_y) {
     settings.flick_show_duration = atoi(show_duration_t->value->cstring);    
+  }
+
+  //enable weather
+  Tuple *enable_weather_t = dict_find(iter, MESSAGE_KEY_enable_weather);
+  if (enable_weather_t) {
+    settings.weather_enabled = enable_weather_t->value->int32 == 1;
+  }
+
+  //get the temperature
+  Tuple *temperature_t = dict_find(iter, MESSAGE_KEY_temperature);
+  temperature = (int)temperature_t->value->int32;
+
+  //toggle between faherenheit and celsius
+  Tuple *temperature_format_t = dict_find(iter, MESSAGE_KEY_temperature_format);
+  if (temperature_format_t) {
+    settings.temperature_format = temperature_format_t->value->int32 == 1;
+  }
+
+  //get weather api key
+  Tuple *weather_api_key_t = dict_find(iter, MESSAGE_KEY_weather_api_key);  
+  if(weather_api_key_t) {
+    settings.weather_api_key = weather_api_key_t->value->cstring;    
   }    
    
   #ifdef PBL_COLOR

--- a/src/c/weather.c
+++ b/src/c/weather.c
@@ -1,0 +1,21 @@
+#include <pebble.h>
+#include "weather.h"
+#include "globals.h"
+
+void update_temperature() {
+    static char s_buffer[25];
+    APP_LOG(APP_LOG_LEVEL_ERROR, "Temp is: %d", temperature);
+    if (settings.temperature_format) {
+        snprintf(s_buffer, sizeof(s_buffer), "%d", temperature);
+    }
+    else {
+        snprintf(s_buffer, sizeof(s_buffer), "%d", (int)(32 + ((temperature) * 1.8 )));
+    }
+    text_layer_set_text(layer_weather_text, s_buffer);
+}
+
+void enable_weather(bool enableWeather) {
+  layer_set_hidden(text_layer_get_layer(layer_weather_text),!enableWeather);
+  layer_set_hidden(bitmap_layer_get_layer(layer_bt),enableWeather);
+  layer_set_hidden(bitmap_layer_get_layer(layer_qt),enableWeather);
+}

--- a/src/c/weather.h
+++ b/src/c/weather.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <pebble.h>
+
+void update_temperature();
+void enable_weather(bool enableWeather);

--- a/src/c/window.c
+++ b/src/c/window.c
@@ -3,6 +3,7 @@
 #include "globals.h"
 #include "callbacks.h"
 #include "time.h"
+#include "weather.h"
 #include "gbitmap_color_palette_manipulator.h"
 
 void window_load(Window *window)  
@@ -26,6 +27,7 @@ void window_load(Window *window)
 void window_unload(Window *window)
 {
   text_layer_destroy(layer_menubar_text);
+  text_layer_destroy(layer_weather_text);
   text_layer_destroy(layer_time);
   text_layer_destroy(layer_date);
   
@@ -113,10 +115,21 @@ void window_update()
   }
 
   show_datatime_window((settings.show_datatime_window && !settings.flick_enabled));
+
+  //show/hide the weather/bt/qt icons
+  if (settings.weather_enabled) 
+  {
+    enable_weather(true);
+  }
+  else 
+  {
+    enable_weather(false);
+  }
   
   //check battery - to update menubar text if needed
   update_time();
   update_date();
+  update_temperature();
   battery_callback(battery_state_service_peek());
  
   
@@ -191,6 +204,8 @@ void create_text_layers()
   
   layer_menubar_text = text_layer_create(
     GRect(TIME_SMALL_X, TIME_SMALL_Y, TIME_SMALL_W, TIME_SMALL_H));  
+  layer_weather_text = text_layer_create(
+    GRect(WEATHER_X, WEATHER_Y, WEATHER_W, WEATHER_H));  
   layer_time = text_layer_create(
     GRect(TIME_BIG_X, TIME_BIG_Y, TIME_BIG_W, TIME_BIG_H));   
   layer_date = text_layer_create(
@@ -198,6 +213,7 @@ void create_text_layers()
   
   
   set_up_text_layer(layer_menubar_text, GColorClear, GColorBlack, "44:44", font_menubar,GTextAlignmentCenter);
+  set_up_text_layer(layer_weather_text, GColorClear, GColorBlack, "xxx", font_menubar,GTextAlignmentCenter);
   set_up_text_layer(layer_time, GColorClear, GColorBlack, "44:44", font_time,GTextAlignmentCenter);
   set_up_text_layer(layer_date, GColorClear, GColorBlack, "44-44-2044", font_date,GTextAlignmentCenter);
 }
@@ -236,6 +252,7 @@ void add_layers_to_window(Layer *window_layer)
   
   //text
   layer_add_child(window_layer,text_layer_get_layer(layer_menubar_text));  
+  layer_add_child(window_layer,text_layer_get_layer(layer_weather_text));
   layer_add_child(window_layer,text_layer_get_layer(layer_time));
   layer_add_child(window_layer,text_layer_get_layer(layer_date));
 }

--- a/src/pkjs/config.js
+++ b/src/pkjs/config.js
@@ -120,7 +120,7 @@ module.exports = [
       }
       
       ]},
-      
+
       {
       "type": "section",
       "items": [
@@ -138,6 +138,35 @@ module.exports = [
       
       ]}
        
+    ]
+  },
+  {
+    "type": "section",
+    "items": [
+      {
+        "type": "heading",
+        "defaultValue": "Weather",
+      },
+      {
+        "type": "toggle",
+        "messageKey": "enable_weather",
+        "label": "Enable weather (replaces BT and QT indicators)",
+        "defaultValue": false
+      },
+      {
+        "type": "input",
+        "messageKey": "weather_api_key",
+        "defaultValue": "1111111111",
+        "description": "Get key at openweathermap.org",
+        "label": "Open Weather Map API Key",
+      },
+      {
+        "type": "toggle",
+        "messageKey": "temperature_format",
+        "label": "Temperature format",
+        "description": "Fahrenheit/Celsius",
+        "defaultValue": false
+      }
     ]
   },
   {

--- a/src/pkjs/custom-clay.js
+++ b/src/pkjs/custom-clay.js
@@ -3,6 +3,7 @@ module.exports = function() {
   var windowToggle;
   var centerPosToggle;
   var flickToHide;
+  var weatherToggle;
   
    function toggleXYPosition()
   { 
@@ -23,7 +24,7 @@ module.exports = function() {
       clayConfig.getItemByMessageKey('flick_show_duration').disable();
     }
   }
-  
+
   function togglePosition()
   { 
    if (this.get()) {
@@ -43,6 +44,17 @@ module.exports = function() {
     }
   }
   
+  function toggleWeather()
+  {
+    if (this.get()) {
+       clayConfig.getItemByMessageKey('temperature_format').enable();
+       clayConfig.getItemByMessageKey('weather_api_key').enable();
+    }
+    else {
+       clayConfig.getItemByMessageKey('temperature_format').disable();
+       clayConfig.getItemByMessageKey('weather_api_key').disable();
+    }
+  }
   
   
   
@@ -66,6 +78,10 @@ module.exports = function() {
     togglePosition.call(windowToggle);
     windowToggle.on('change', togglePosition);
     
+    //if weather is disabled - disable all related settings
+    weatherToggle = clayConfig.getItemByMessageKey('enable_weather');
+    toggleWeather.call(weatherToggle);
+    weatherToggle.on('change', toggleWeather);
    
   });
   

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -8,3 +8,77 @@ var clay = new Clay(clayConfig, customClay);
 // var clayConfig = require('./config');
 // // Initialize Clay
 // var clay = new Clay(clayConfig);
+
+var claySettings = JSON.parse(localStorage.getItem('clay-settings'));
+
+var xhrRequest = function (url, type, callback) {
+  var xhr = new XMLHttpRequest();
+  xhr.onload = function () {
+    callback(this.responseText);
+  };
+  xhr.open(type, url);
+  xhr.send();
+};
+
+function locationSuccess(pos) {
+  // Construct URL
+  console.log("TEST" + claySettings.weather_api_key);
+  var url = "http://api.openweathermap.org/data/2.5/weather?lat=-0.13&lon=51.51&APPID=" + claySettings.weather_api_key;
+
+  // Send request
+  xhrRequest(url, 'GET', 
+    function(responseText) {
+      var json = JSON.parse(responseText);
+
+      // Temperature (in Celsius, because it doesn't suck)
+      var temperature = Math.round(json.main.temp - 273.15);
+      console.log("Temperature is " + temperature);
+      
+      // Push into a dictionary
+      var dictionary = {
+        "TEMPERATURE": temperature
+      };
+
+      // Send to Pebble
+      MessageQueue.sendAppMessage(dictionary,
+        function(e) {
+          console.log("Weather info sent to Pebble successfully!");
+        },
+        function(e) {
+          console.log("Error sending weather info to Pebble!");
+        }
+      );
+    }      
+  );
+}
+
+function locationError(err) {
+  console.log("Error requesting location!");
+}
+
+function getWeather() {
+  navigator.geolocation.getCurrentPosition(
+    locationSuccess,
+    locationError,
+    {timeout: 15000, maximumAge: 60000}
+  );
+}
+
+// Check when watch face opens
+Pebble.addEventListener('ready', 
+  function(e) {
+    console.log("PebbleKit JS ready!");
+
+    // Get weather immediately
+    getWeather();
+  }
+);
+
+// Check when the message is received
+Pebble.addEventListener('appmessage',
+  function(e) {
+    var goal = e.payload.GOAL
+    console.log("AppMessage received!");
+    
+  getWeather();
+});


### PR DESCRIPTION
Most of the changes required to support weather are here, functional, and written the same way your code is.

It is still broken though and I would like if you could check out why so I can finish and push this into your branch:

1. Every clay config transaction I have done since I have reached 100 has been marked as "isTrusted: false". Do you know how to handle this because as of now, Clay won't push settings to the watch because of this.

2. I cannot for the life of me get the temperature from the phone to the watch. I have done this a million time before but now it won't push because "MessageQueue" in index.js is not defined

Other things I need to change:

1. Add a degree symbol to temperature. I think it is just \377 or something like that. Would rather get the temperature working first.

2. Remove the stupid ERROR log I added in weather.c

3. Fix the comments in index.js from when I copied them from my other app / move the weather js into its own file

I guess this is just a code review, since GitHub has no button for that (?).